### PR TITLE
Se agrega timestamp como explicit type casts en varias consultas

### DIFF
--- a/report/sql/query2.sql
+++ b/report/sql/query2.sql
@@ -1,6 +1,6 @@
 -- Casos confirmados por mes
 select 
-        to_char(date_trunc('month', registration_date), 'YYYY-MM') as registration_month
+        to_char(date_trunc('month', registration_date::timestamp), 'YYYY-MM') as registration_month
     ,   to_char(count(*), '999,999,999') as total_cases
     ,   to_char(count(*) / SUM(count(*)) over () * 100, 'fm00D00 %')  as total_cases_percent
 from covid19_case

--- a/report/sql/query3.sql
+++ b/report/sql/query3.sql
@@ -1,6 +1,6 @@
 -- Casos confirmados por semana para los últimos 2 meses
 select 
-        to_char(date_trunc('week', registration_date), 'YYYY-MM-DD') as registration_week
+        to_char(date_trunc('week', registration_date::timestamp), 'YYYY-MM-DD') as registration_week
     ,   to_char(count(*), '999,999,999') as total_cases
 from covid19_case
 where 

--- a/report/sql/query4.sql
+++ b/report/sql/query4.sql
@@ -1,6 +1,6 @@
 -- Casos confirmados en el último mes agrupados por Sexo
 select 
-        max(to_char(date_trunc('month', registration_date), 'YYYY-MM')) as last_registration_month
+        max(to_char(date_trunc('month', registration_date::timestamp), 'YYYY-MM')) as last_registration_month
     ,   case 
             when gender_id = 'F' then 'Female'
             when gender_id = 'M' then 'Male'

--- a/report/sql/query5.sql
+++ b/report/sql/query5.sql
@@ -1,6 +1,6 @@
 -- Casos confirmados en el último mes agrupados por Edad
 select 
-        max(to_char(date_trunc('month', registration_date), 'YYYY-MM')) as last_registration_month
+        max(to_char(date_trunc('month', registration_date::timestamp), 'YYYY-MM')) as last_registration_month
     ,   case 
             when age < 20 then '0<20'
             when age >= 20 and age < 40 then '20-39'

--- a/report/sql/query6.sql
+++ b/report/sql/query6.sql
@@ -1,6 +1,6 @@
 -- Casos confirmados en el último mes agrupados por Localidad
 select 
-        max(to_char(date_trunc('month', registration_date), 'YYYY-MM')) as last_registration_month
+        max(to_char(date_trunc('month', registration_date::timestamp), 'YYYY-MM')) as last_registration_month
     ,   s.state_name
     ,   to_char(count(*), '999,999,999') as total_cases
     ,   to_char(count(*) / SUM(count(*)) over () * 100, 'fm00D00 %')  as total_cases_percent


### PR DESCRIPTION
Se agrega "timesstamp" como explicit type casts en varias queries que utilizan la función "to_char" para comvertir datos de tipo fecha a caracter. Se hace para resolver error que se produce al correr el pipeline en ec2:

ERROR:  function date_trunc(unknown, text) does not exist
LINE 2:         to_char(date_trunc('month', registration_date), 'YYY...
                        ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
